### PR TITLE
Adding testing support to clean up after tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,6 +155,26 @@ export default Metrics.extend({
 
 ```
 
+## Test Support
+`setupExperiments` We provide `this.experiments` in your tests and also clean up experiments after each test.
+
+```js
+import setupExperiments from 'ember-experiments/test-support/setup-experiments';
+
+module('Acceptance | experiments', function(hooks) {
+  setupApplicationTest(hooks);
+  setupExperiments(hooks);
+
+  test('experiments in testing me knees', async function(assert) {
+    this.experiments.set('knee', 'left');
+    await visit('/activate');
+
+    let service = this.owner.lookup('service:experiments');
+
+    assert.ok(this.experiments.isEnabled('knee', 'left'));
+  });
+}})
+```
 
 ### Good To Know's
 * It's safe to setup the same test as many times as you'd like, the test is enabled and a variant is selected on the first `setup`.  Subsequent setups will abort immediately and return the originally selected variant.

--- a/addon-test-support/setup-experiments.js
+++ b/addon-test-support/setup-experiments.js
@@ -1,0 +1,25 @@
+import { settled } from '@ember/test-helpers';
+
+export default function setupExperiments(hooks = self) {
+  hooks.beforeEach(function() {
+    if (!this.owner) {
+      throw new Error(`You must call one of the ember-qunit setupTest(),
+      setupRenderingTest() or setupApplicationTest() methods before
+      calling setupExperiments()`);
+    }
+
+    let experiments = this.owner.lookup('service:experiments');
+
+    if (experiments) {
+      this.experiments = experiments
+    }
+  });
+
+  hooks.afterEach(function() {
+    return settled().then(() => {
+      if(this.experiments && typeof this.experiments.clearExperiments === 'function') {
+        this.experiments.clearExperiments()
+      }
+    });
+  });
+}

--- a/tests/acceptance/activate-experiments-test.js
+++ b/tests/acceptance/activate-experiments-test.js
@@ -1,9 +1,11 @@
 import { module, test } from 'qunit';
 import { visit } from '@ember/test-helpers';
 import { setupApplicationTest } from 'ember-qunit';
+import setupExperiments from 'ember-experiments/test-support/setup-experiments';
 
 module('Acceptance | activate experiments', function(hooks) {
   setupApplicationTest(hooks);
+  setupExperiments(hooks);
 
   test('visiting /activate', async function(assert) {
     await visit('/activate?experiments=test1/variation1');
@@ -18,5 +20,24 @@ module('Acceptance | activate experiments', function(hooks) {
 
     assert.equal(service.getVariation('test1'), 'variation1');
     assert.equal(service.getVariation('test2'), 'variation2');
+  });
+
+  test('setup an experiment in a test and it is torn down', async function(assert) {
+    this.experiments.enable('test1', 'variation1');
+    await visit('/activate');
+    let service = this.owner.lookup('service:experiments');
+
+    assert.ok(service.isEnabled('test1', 'variation1'));
+    assert.notOk(service.isEnabled('test2', 'variation2'));
+  });
+
+  test('setup an experiment in a test and it is torn down', async function(assert) {
+    this.experiments.enable('test2', 'variation2');
+
+    await visit('/activate');
+    let service = this.owner.lookup('service:experiments');
+
+    assert.ok(service.isEnabled('test2', 'variation2'));
+    assert.notOk(service.isEnabled('test1', 'variation1'));
   });
 });

--- a/tests/unit/services/experiments-test.js
+++ b/tests/unit/services/experiments-test.js
@@ -1,19 +1,10 @@
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
+import setupExperiments from 'ember-experiments/test-support/setup-experiments';
 
 module('Unit | Service | experiments', function(hooks) {
   setupTest(hooks);
-
-  hooks.beforeEach(function() {
-    let service = this.owner.lookup('service:experiments');
-    service.clearExperiments();
-  });
-
-  // Replace this with your real tests.
-  test('it exists', function(assert) {
-    let service = this.owner.lookup('service:experiments');
-    assert.ok(service);
-  });
+  setupExperiments(hooks);
 
   test('it knows how to sort variations', function(assert) {
     let service = this.owner.lookup('service:experiments');


### PR DESCRIPTION
Import `setupExperiments` for both acceptance and integration test.
`import setupExperiments from 'ember-experiments/test-support/setup-experiments';`

After each the `clearExperiments()` is called to clean up any experiments that were setup during the test.

```js
import setupExperiments from 'ember-experiments/test-support/setup-experiments';

module('Acceptance | experiments', function(hooks) {
  setupApplicationTest(hooks);
  setupExperiments(hooks);

  test('experiments in testing me knees', async function(assert) {
    this.experiments.set('knee', 'left');
    await visit('/activate');

    let service = this.owner.lookup('service:experiments');

    assert.ok(this.experiments.isEnabled('knee', 'left'));
  });
}})

```